### PR TITLE
Give each CLI platform its own directory in the release package

### DIFF
--- a/ClipmanCli/Build.ps1
+++ b/ClipmanCli/Build.ps1
@@ -16,8 +16,8 @@ if ($outputRoot -eq $sourceRoot -or $outputRoot.StartsWith($sourceRoot + '\', [S
 $version = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'VERSION') -Raw).Trim()
 if ([string]::IsNullOrWhiteSpace($version)) { throw 'VERSION is empty.' }
 $packageFiles = @(
-    @{ Source = Join-Path $PSScriptRoot 'Manual.html'; Destination = 'Manual.html' },
-    @{ Source = Join-Path $PSScriptRoot 'clipman-cli.1'; Destination = 'clipman-cli.1' },
+    @{ Source = Join-Path $PSScriptRoot 'Manual.html'; Destination = 'manual/Manual.html' },
+    @{ Source = Join-Path $PSScriptRoot 'clipman-cli.1'; Destination = 'manual/clipman-cli.1' },
     @{ Source = Join-Path (Split-Path -Parent $PSScriptRoot) 'LICENSE.txt'; Destination = 'LICENSE.txt' }
 )
 foreach ($file in $packageFiles) {
@@ -25,13 +25,16 @@ foreach ($file in $packageFiles) {
         throw "Required package file is missing: $($file.Source)"
     }
 }
+# Every binary is named clipman-cli and identified by its directory, so
+# installing one is a move rather than a rename.
 $targets = @(
-    @{ os = 'windows'; arch = 'amd64'; arm = '';  output = 'clipman-cli-windows-amd64.exe' },
-    @{ os = 'linux';   arch = 'amd64'; arm = '';  output = 'clipman-cli-linux-amd64' },
-    @{ os = 'linux';   arch = 'arm';   arm = '7'; output = 'clipman-cli-linux-armv7' },
-    @{ os = 'linux';   arch = 'arm64'; arm = '';  output = 'clipman-cli-linux-arm64' },
-    @{ os = 'darwin';  arch = 'amd64'; arm = '';  output = 'clipman-cli-macos-amd64' },
-    @{ os = 'darwin';  arch = 'arm64'; arm = '';  output = 'clipman-cli-macos-arm64' }
+    @{ os = 'windows'; arch = 'amd64'; arm = '';  directory = 'windows-amd64'; binary = 'clipman-cli.exe' },
+    @{ os = 'windows'; arch = 'arm64'; arm = '';  directory = 'windows-arm64'; binary = 'clipman-cli.exe' },
+    @{ os = 'linux';   arch = 'amd64'; arm = '';  directory = 'linux-amd64';   binary = 'clipman-cli' },
+    @{ os = 'linux';   arch = 'arm';   arm = '7'; directory = 'linux-armv7';   binary = 'clipman-cli' },
+    @{ os = 'linux';   arch = 'arm64'; arm = '';  directory = 'linux-arm64';   binary = 'clipman-cli' },
+    @{ os = 'darwin';  arch = 'amd64'; arm = '';  directory = 'macos-amd64';   binary = 'clipman-cli' },
+    @{ os = 'darwin';  arch = 'arm64'; arm = '';  directory = 'macos-arm64';   binary = 'clipman-cli' }
 )
 
 $staging = Join-Path $outputRoot 'staging'
@@ -56,7 +59,9 @@ try {
         $env:GOARCH = $target.arch
         if ($target.arm) { $env:GOARM = $target.arm }
         else { Remove-Item Env:GOARM -ErrorAction SilentlyContinue }
-        $destination = Join-Path $staging $target.output
+        $targetDirectory = Join-Path $staging $target.directory
+        New-Item -ItemType Directory -Path $targetDirectory -Force | Out-Null
+        $destination = Join-Path $targetDirectory $target.binary
         & $GoExecutable build -trimpath -ldflags "-s -w -X main.version=$version" -o $destination ./cmd/clipman-cli
         if ($LASTEXITCODE -ne 0) { throw "Build failed for $($target.os)/$($target.arch)." }
     }
@@ -69,14 +74,19 @@ finally {
     }
 }
 
+# Paths stay relative with forward slashes so that `sha256sum -c SHA256SUMS`
+# verifies the whole package from its root on any platform.
 $records = foreach ($target in $targets) {
-    $path = Join-Path $staging $target.output
+    $relative = "$($target.directory)/$($target.binary)"
+    $path = Join-Path $staging $relative
     $hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
-    "$hash  $($target.output)"
+    "$hash  $relative"
 }
 [IO.File]::WriteAllText((Join-Path $staging 'SHA256SUMS'), (($records | Sort-Object) -join "`n") + "`n", [Text.UTF8Encoding]::new($false))
 foreach ($file in $packageFiles) {
-    Copy-Item -LiteralPath $file.Source -Destination (Join-Path $staging $file.Destination)
+    $destination = Join-Path $staging $file.Destination
+    New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+    Copy-Item -LiteralPath $file.Source -Destination $destination
 }
 
 $final = Join-Path $outputRoot "ClipmanCli-$version"

--- a/ClipmanCli/Manual.html
+++ b/ClipmanCli/Manual.html
@@ -64,6 +64,7 @@ clipman-cli get --name deploy-command &gt; command.txt</code></pre>
         <tr><td><code>--insecure</code></td><td>Disable HTTPS certificate verification for the selected server. This is an explicit last resort for a trusted private network; it prints a warning and must not be used across an untrusted network.</td></tr>
         <tr><td><code>--json</code></td><td>Produce structured JSON where the selected command supports it.</td></tr>
         <tr><td><code>--quiet</code> or <code>-q</code></td><td>Suppress nonessential status messages. Security warnings remain visible.</td></tr>
+        <tr><td><code>--verbose</code></td><td>Write diagnostic messages to standard error: the configuration file in use, the server address, the short history-bucket fingerprint, and the revision and entry count of each download. It never writes the token, the history password, or the full database identifier. <code>--quiet</code> takes precedence.</td></tr>
         <tr><td><code>--version</code></td><td>Show the CLI version.</td></tr>
       </tbody>
     </table>
@@ -91,7 +92,10 @@ clipman-cli get --name deploy-command &gt; command.txt</code></pre>
     <pre><code>clipman-cli get 3
 clipman-cli get --id 0123456789abcdef0123456789abcdef
 clipman-cli get --search kubectl --first
-clipman-cli rm --name old-command --yes</code></pre>
+clipman-cli rm --name old-command --yes
+clipman-cli get 3 --json
+clipman-cli rm 3 --yes</code></pre>
+    <p>Command options may be written before or after the index, so <code>get 3 --json</code> and <code>get --json 3</code> are equivalent. To select an entry whose name or search text begins with a hyphen, put <code>--</code> before it.</p>
     <p>An ambiguous search is not treated as bulk deletion. Use a unique ID or a reviewed visible index.</p>
     <p>Clipman CLI preserves optional HTML and RTF fields created by Windows or Mac Rich Text history when it reads, merges, and writes shared entries. CLI output remains the authoritative plain-text fallback and does not emit rich clipboard formats.</p>
 
@@ -158,6 +162,16 @@ clipman-cli get --kind templates --name today</code></pre>
     </table>
 
     <h2 id="changelog">Changelog</h2>
+    <h3>0.3.0 development preview</h3>
+    <ul>
+      <li>Fixed <code>get</code> and <code>rm</code> rejecting an option written after the index. <code>get 3 --json</code> and <code>rm 3 --yes</code> reported "only one index may be supplied" and now work as documented.</li>
+      <li>Fixed <code>sync</code> reporting "History is current: 0 entries" when no database existed for the token and history password, which could hide a mistyped password. It now says so explicitly.</li>
+      <li>Fixed a negative index reporting "entry not found" instead of a usage error.</li>
+      <li>Fixed <code>--help</code> and <code>-h</code> being ignored when another option preceded them, so <code>get --json --help</code> now prints the command syntax and exits successfully.</li>
+      <li>Replaced the generated option dump printed on a usage error with the command's one-line syntax, which is shorter and clearer to read aloud.</li>
+      <li>Implemented <code>--verbose</code>, which was previously accepted and ignored, and documented it.</li>
+      <li><code>status --json</code> now reports <code>entries</code> as <code>null</code> rather than <code>-1</code> when <code>--refresh</code> was not used.</li>
+    </ul>
     <h3>0.2.0 development preview</h3>
     <ul>
       <li>Returned Clipman CLI to active development after practical server testing and community feedback.</li>

--- a/ClipmanCli/Manual.html
+++ b/ClipmanCli/Manual.html
@@ -150,13 +150,20 @@ clipman-cli get --kind templates --name today</code></pre>
     </table>
 
     <h2 id="files">Included Files</h2>
+    <p>Each platform has its own directory, and the program inside every one of them is called <code>clipman-cli</code>. Installing it is therefore a move, with no renaming step: pick the directory matching your operating system and architecture and copy the program out of it.</p>
     <table>
-      <thead><tr><th>File</th><th>Purpose</th></tr></thead>
+      <thead><tr><th>Path</th><th>Purpose</th></tr></thead>
       <tbody>
-        <tr><td><code>clipman-cli-PLATFORM</code></td><td>Standalone command-line client for the named operating system and architecture.</td></tr>
-        <tr><td><code>Manual.html</code></td><td>This accessible manual.</td></tr>
-        <tr><td><code>clipman-cli.1</code></td><td>Unix manual page source.</td></tr>
-        <tr><td><code>SHA256SUMS</code></td><td>SHA-256 checksums for the supplied binaries.</td></tr>
+        <tr><td><code>windows-amd64/clipman-cli.exe</code></td><td>Windows on a 64-bit Intel or AMD processor.</td></tr>
+        <tr><td><code>windows-arm64/clipman-cli.exe</code></td><td>Windows on a 64-bit ARM processor.</td></tr>
+        <tr><td><code>macos-amd64/clipman-cli</code></td><td>macOS on an Intel processor.</td></tr>
+        <tr><td><code>macos-arm64/clipman-cli</code></td><td>macOS on Apple silicon.</td></tr>
+        <tr><td><code>linux-amd64/clipman-cli</code></td><td>Linux on a 64-bit Intel or AMD processor.</td></tr>
+        <tr><td><code>linux-arm64/clipman-cli</code></td><td>Linux on a 64-bit ARM processor.</td></tr>
+        <tr><td><code>linux-armv7/clipman-cli</code></td><td>Linux on a 32-bit ARMv7 processor.</td></tr>
+        <tr><td><code>manual/Manual.html</code></td><td>This accessible manual.</td></tr>
+        <tr><td><code>manual/clipman-cli.1</code></td><td>Unix manual page source.</td></tr>
+        <tr><td><code>SHA256SUMS</code></td><td>SHA-256 checksums for the supplied binaries. Run <code>sha256sum -c SHA256SUMS</code> from this directory to verify every one of them.</td></tr>
         <tr><td><code>LICENSE.txt</code></td><td>MIT licence terms.</td></tr>
       </tbody>
     </table>
@@ -164,6 +171,9 @@ clipman-cli get --kind templates --name today</code></pre>
     <h2 id="changelog">Changelog</h2>
     <h3>0.3.0 development preview</h3>
     <ul>
+      <li>Restructured the release package so each platform has its own directory holding a program simply called <code>clipman-cli</code>. Installing it is now a move instead of a rename.</li>
+      <li>Added a Windows ARM64 build.</li>
+      <li>Moved the manual and manual page into a <code>manual</code> directory.</li>
       <li>Fixed <code>get</code> and <code>rm</code> rejecting an option written after the index. <code>get 3 --json</code> and <code>rm 3 --yes</code> reported "only one index may be supplied" and now work as documented.</li>
       <li>Fixed <code>sync</code> reporting "History is current: 0 entries" when no database existed for the token and history password, which could hide a mistyped password. It now says so explicitly.</li>
       <li>Fixed a negative index reporting "entry not found" instead of a usage error.</li>

--- a/ClipmanCli/build.sh
+++ b/ClipmanCli/build.sh
@@ -28,40 +28,53 @@ done
 rm -rf "$staging"
 mkdir -p "$staging"
 
+# Every binary is named clipman-cli and identified by its directory, so
+# installing one is a move rather than a rename.
+artifacts=''
 build() {
   goos=$1
   goarch=$2
   goarm=$3
-  artifact=$4
+  directory=$4
+  binary=$5
+  mkdir -p "$staging/$directory"
   if [ -n "$goarm" ]; then
     CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" \
-      go build -trimpath -ldflags "-s -w -X main.version=$version" -o "$staging/$artifact" ./cmd/clipman-cli
+      go build -trimpath -ldflags "-s -w -X main.version=$version" -o "$staging/$directory/$binary" ./cmd/clipman-cli
   else
     CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
-      go build -trimpath -ldflags "-s -w -X main.version=$version" -o "$staging/$artifact" ./cmd/clipman-cli
+      go build -trimpath -ldflags "-s -w -X main.version=$version" -o "$staging/$directory/$binary" ./cmd/clipman-cli
   fi
+  artifacts="$artifacts $directory/$binary"
 }
 
 cd "$root"
 go test ./...
 go vet ./...
-build windows amd64 '' clipman-cli-windows-amd64.exe
-build linux amd64 '' clipman-cli-linux-amd64
-build linux arm 7 clipman-cli-linux-armv7
-build linux arm64 '' clipman-cli-linux-arm64
-build darwin amd64 '' clipman-cli-macos-amd64
-build darwin arm64 '' clipman-cli-macos-arm64
+build windows amd64 '' windows-amd64 clipman-cli.exe
+build windows arm64 '' windows-arm64 clipman-cli.exe
+build linux amd64 '' linux-amd64 clipman-cli
+build linux arm 7 linux-armv7 clipman-cli
+build linux arm64 '' linux-arm64 clipman-cli
+build darwin amd64 '' macos-amd64 clipman-cli
+build darwin arm64 '' macos-arm64 clipman-cli
 
+# Paths stay relative so that `sha256sum -c SHA256SUMS` verifies the whole
+# package from its root.
 (
   cd "$staging"
+  # sed normalizes the binary-mode "*" marker some sha256sum builds emit, so
+  # this file is byte-identical to the one Build.ps1 writes.
+  # shellcheck disable=SC2086
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum clipman-cli-* | LC_ALL=C sort > SHA256SUMS
+    sha256sum $artifacts
   else
-    shasum -a 256 clipman-cli-* | LC_ALL=C sort > SHA256SUMS
-  fi
+    shasum -a 256 $artifacts
+  fi | sed 's/^\([0-9a-f]\{64\}\) \*/\1  /' | LC_ALL=C sort > SHA256SUMS
 )
-cp "$root/Manual.html" "$staging/Manual.html"
-cp "$root/clipman-cli.1" "$staging/clipman-cli.1"
+mkdir -p "$staging/manual"
+cp "$root/Manual.html" "$staging/manual/Manual.html"
+cp "$root/clipman-cli.1" "$staging/manual/clipman-cli.1"
 cp "$license" "$staging/LICENSE.txt"
 rm -rf "$final"
 mv "$staging" "$final"

--- a/ClipmanCli/clipman-cli.1
+++ b/ClipmanCli/clipman-cli.1
@@ -100,6 +100,15 @@ be visible in the process list.
 .TP
 .B rm
 Delete exactly one entry and add a synchronization tombstone.
+.IP
+.B get
+and
+.B rm
+accept their index before or after the command options, so
+.B "get 3 --json"
+and
+.B "get --json 3"
+are equivalent.
 .TP
 .B pick
 Display a numbered list on the controlling terminal and write the selected
@@ -142,6 +151,14 @@ Produce structured JSON where supported.
 .TP
 .BR --quiet , " -q"
 Suppress nonessential status messages. Security warnings remain visible.
+.TP
+.B --verbose
+Write diagnostic messages to standard error: the configuration file in use, the
+server address, the short history-bucket fingerprint, and the revision and
+entry count of each download. It never writes the token, the history password,
+or the full database identifier.
+.B --quiet
+takes precedence.
 .TP
 .B --version
 Show the CLI version.

--- a/ClipmanCli/clipman-cli.1
+++ b/ClipmanCli/clipman-cli.1
@@ -224,12 +224,30 @@ History password required or incorrect, or database authentication failed.
 .B 6
 Requested entry or database not found.
 .SH FILES
+The release package gives every platform its own directory and names the
+program
+.B clipman-cli
+inside each one, so installing it is a move rather than a rename. The
+directories are
+.IR windows-amd64 ,
+.IR windows-arm64 ,
+.IR macos-amd64 ,
+.IR macos-arm64 ,
+.IR linux-amd64 ,
+.IR linux-arm64 ,
+and
+.IR linux-armv7 .
 .TP
-.I Manual.html
+.I manual/Manual.html
 Accessible full manual supplied with the binaries.
 .TP
+.I manual/clipman-cli.1
+This manual page.
+.TP
 .I SHA256SUMS
-SHA-256 checksums for all supplied platform binaries.
+SHA-256 checksums for all supplied platform binaries. Run
+.B sha256sum -c SHA256SUMS
+from the package root to verify them.
 .TP
 .I LICENSE.txt
 MIT License terms.

--- a/ClipmanCli/cmd/clipman-cli/main.go
+++ b/ClipmanCli/cmd/clipman-cli/main.go
@@ -47,6 +47,10 @@ func fail(code int, format string, args ...any) error {
 	return appError{code: code, err: fmt.Errorf(format, args...)}
 }
 
+// errHelpRequested reports that a command printed its own usage in response to
+// --help or -h. It is not a failure and must not be written to standard error.
+var errHelpRequested = errors.New("help requested")
+
 type optionalString struct {
 	value string
 	set   bool
@@ -146,7 +150,7 @@ func hasHelpOption(args []string) bool {
 	return len(args) > 0 && (args[0] == "--help" || args[0] == "-h")
 }
 func printError(err error) int {
-	if err == nil {
+	if err == nil || errors.Is(err, errHelpRequested) {
 		return 0
 	}
 	code := 1
@@ -231,6 +235,83 @@ func addOutputFlags(fs *flag.FlagSet, g *globals) {
 	fs.BoolVar(&g.quiet, "quiet", g.quiet, "suppress status messages")
 	fs.BoolVar(&g.quiet, "q", g.quiet, "suppress status messages")
 	fs.BoolVar(&g.verbose, "verbose", g.verbose, "write diagnostic status messages")
+}
+
+// newFlagSet builds a command flag set that writes nothing itself, so that
+// parseCommandFlags is the single place that reports usage and errors. The flag
+// package would otherwise repeat the error and add a long generated option
+// dump, which is unordered and reads poorly aloud in a screen reader.
+func newFlagSet(command string) *flag.FlagSet {
+	fs := flag.NewFlagSet(command, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	return fs
+}
+
+// parseCommandFlags parses args and turns a --help or -h anywhere in the
+// command line into the command's usage on standard output, so that
+// `get --json --help` behaves like `get --help`. Any other parse failure gets
+// the same one-line syntax on standard error, followed by the error itself.
+func parseCommandFlags(fs *flag.FlagSet, command string, args []string) error {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printCommandUsage(os.Stdout, command)
+			return errHelpRequested
+		}
+		printCommandUsage(os.Stderr, command)
+		return fail(2, "%v", err)
+	}
+	return nil
+}
+
+// permuteArgs moves positional operands behind the options so that options may
+// follow an index, as the documented syntax implies. The flag package stops at
+// the first operand, which would otherwise make `get 0 --json` read --json as a
+// second index and report a confusing "only one index may be supplied".
+func permuteArgs(fs *flag.FlagSet, args []string) []string {
+	options := make([]string, 0, len(args))
+	operands := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			operands = append(operands, args[i+1:]...)
+			break
+		}
+		if len(arg) < 2 || !strings.HasPrefix(arg, "-") {
+			operands = append(operands, arg)
+			continue
+		}
+		options = append(options, arg)
+		if strings.Contains(arg, "=") {
+			continue
+		}
+		defined := fs.Lookup(strings.TrimLeft(arg, "-"))
+		if defined == nil {
+			continue
+		}
+		if boolValue, ok := defined.Value.(interface{ IsBoolFlag() bool }); ok && boolValue.IsBoolFlag() {
+			continue
+		}
+		if i+1 < len(args) {
+			i++
+			options = append(options, args[i])
+		}
+	}
+	if len(operands) == 0 {
+		return options
+	}
+	// The separator keeps an operand that begins with "-" from being reparsed
+	// as an option once it has moved behind the options.
+	return append(append(options, "--"), operands...)
+}
+
+// verbosef writes a diagnostic line to standard error for --verbose. It never
+// reports a token, a password, or a full database identifier.
+func verbosef(g globals, format string, args ...any) {
+	if !g.verbose || g.quiet {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "clipman-cli: "+format+"\n", args...)
 }
 
 // tlsOptionsForGlobals resolves the TLS trust options to use for a connection,
@@ -399,6 +480,9 @@ func loadContext(g globals) (*appContext, error) {
 	if err != nil {
 		return nil, fail(2, "invalid server configuration: %v", err)
 	}
+	verbosef(g, "configuration %s", path)
+	verbosef(g, "server %s", serverURL)
+	verbosef(g, "history bucket %s", fingerprint(databaseID))
 	limits := clipdb.Limits{MaxBlobBytes: cfg.Limits.MaxBlobBytes, MaxJSONBytes: cfg.Limits.MaxJSONBytes, MaxEntries: cfg.Limits.MaxEntries, MaxTextBytes: cfg.Limits.MaxTextBytes}
 	engine := &syncengine.Engine{Client: client, Password: password, Limits: limits, Retries: 3}
 	return &appContext{globals: g, configPath: path, config: cfg, token: token, password: password, databaseID: databaseID, client: client, engine: engine}, nil
@@ -430,8 +514,7 @@ func resolvePassword(g globals, cfg config.Config, allowPrompt bool) (string, er
 }
 
 func runInit(g globals, args []string) error {
-	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("init")
 	addOutputFlags(fs, &g)
 	tokenValue := fs.String("token", "", "server token (visible in process lists)")
 	tokenFile := fs.String("token-file", "", "read server token from a file")
@@ -440,8 +523,8 @@ func runInit(g globals, args []string) error {
 	machine := fs.String("machine", "", "source machine name")
 	nonInteractive := fs.Bool("non-interactive", false, "do not prompt")
 	force := fs.Bool("force", false, "replace existing configuration")
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "init", args); err != nil {
+		return err
 	}
 	savePasswordExplicit := false
 	fs.Visit(func(f *flag.Flag) {
@@ -689,12 +772,11 @@ func runInit(g globals, args []string) error {
 }
 
 func runStatus(ctx *appContext, args []string) error {
-	fs := flag.NewFlagSet("status", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("status")
 	addOutputFlags(fs, &ctx.globals)
 	refresh := fs.Bool("refresh", false, "download and validate the database")
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "status", args); err != nil {
+		return err
 	}
 	callCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -711,7 +793,9 @@ func runStatus(ctx *appContext, args []string) error {
 	if err != nil {
 		return mapRuntimeError("database status failed", err)
 	}
-	entries := -1
+	// entries stays null in JSON unless --refresh actually counted them, so a
+	// consumer cannot mistake "not counted" for a real count.
+	var entries any
 	if *refresh && exists {
 		state, readErr := ctx.engine.Read(callCtx)
 		if readErr != nil {
@@ -731,7 +815,7 @@ func runStatus(ctx *appContext, args []string) error {
 			return fail(1, "cannot write output: %v", err)
 		}
 	}
-	if entries >= 0 {
+	if entries != nil {
 		if _, err = fmt.Printf("Entries: %d\n", entries); err != nil {
 			return fail(1, "cannot write output: %v", err)
 		}
@@ -740,11 +824,10 @@ func runStatus(ctx *appContext, args []string) error {
 }
 
 func runSync(ctx *appContext, args []string) error {
-	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("sync")
 	addOutputFlags(fs, &ctx.globals)
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "sync", args); err != nil {
+		return err
 	}
 	if len(fs.Args()) > 0 {
 		return fail(2, "sync takes no positional arguments")
@@ -759,14 +842,20 @@ func runSync(ctx *appContext, args []string) error {
 		return writeJSON(map[string]any{"revision": state.Revision, "database_exists": state.Exists, "entries": len(state.Database.Entries), "uploaded": false})
 	}
 	if !ctx.globals.quiet {
-		fmt.Fprintf(os.Stderr, "History is current: %d entries.\n", len(state.Database.Entries))
+		// An absent database is not an empty history: it usually means the
+		// history password or token differs from the one that holds the data,
+		// so saying "history is current" here would hide a typed password.
+		if !state.Exists {
+			fmt.Fprintln(os.Stderr, "No history exists on the server for this token and history password yet.")
+		} else {
+			fmt.Fprintf(os.Stderr, "History is current: %d entries.\n", len(state.Database.Entries))
+		}
 	}
 	return nil
 }
 
 func runList(ctx *appContext, args []string) error {
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("list")
 	addOutputFlags(fs, &ctx.globals)
 	count := fs.Int("n", 20, "maximum entries")
 	all := fs.Bool("all", false, "list all entries")
@@ -775,8 +864,8 @@ func runList(ctx *appContext, args []string) error {
 	kind := fs.String("kind", ctx.config.DefaultKind, "history, templates, or all")
 	pinned := fs.Bool("pinned-first", ctx.config.PinnedFirst, "show pinned entries first")
 	porcelain := fs.Bool("porcelain", false, "stable tab-separated output")
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "list", args); err != nil {
+		return err
 	}
 	state, err := readState(ctx)
 	if err != nil {
@@ -880,8 +969,7 @@ func runGet(ctx *appContext, args []string) error {
 }
 
 func runPut(ctx *appContext, args []string) error {
-	fs := flag.NewFlagSet("put", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("put")
 	addOutputFlags(fs, &ctx.globals)
 	file := fs.String("file", "", "read text from file")
 	textValue := fs.String("text", "", "text to store")
@@ -890,8 +978,8 @@ func runPut(ctx *appContext, args []string) error {
 	pin := fs.Bool("pin", false, "pin the entry")
 	template := fs.Bool("template", false, "create a template entry")
 	duplicate := fs.String("duplicate", "movetotop", "ignore, movetotop, or keep")
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "put", args); err != nil {
+		return err
 	}
 	switch strings.ToLower(strings.TrimSpace(*duplicate)) {
 	case "ignore", "movetotop", "keep":
@@ -943,8 +1031,7 @@ func runPut(ctx *appContext, args []string) error {
 }
 
 func runRemove(ctx *appContext, args []string) error {
-	fs := flag.NewFlagSet("rm", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("rm")
 	addOutputFlags(fs, &ctx.globals)
 	id := fs.String("id", "", "exact entry ID")
 	name := fs.String("name", "", "exact entry name")
@@ -952,8 +1039,8 @@ func runRemove(ctx *appContext, args []string) error {
 	kindValue := fs.String("kind", ctx.config.DefaultKind, "history, templates, or all")
 	yes := fs.Bool("yes", false, "skip confirmation")
 	caseSensitive := fs.Bool("case-sensitive", false, "case-sensitive name/search")
-	if err := fs.Parse(args); err != nil {
-		return fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "rm", permuteArgs(fs, args)); err != nil {
+		return err
 	}
 	selector, err := buildSelector(fs.Args(), *id, *name, *search, false, *caseSensitive)
 	if err != nil {
@@ -1109,14 +1196,13 @@ func runMenu(ctx *appContext, args []string) error {
 }
 
 func interactiveEntries(ctx *appContext, args []string, command string) ([]model.Entry, error) {
-	fs := flag.NewFlagSet(command, flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet(command)
 	count := fs.Int("n", 20, "maximum entries")
 	all := fs.Bool("all", false, "show all entries")
 	kindValue := fs.String("kind", ctx.config.DefaultKind, "history, templates, or all")
 	pinned := fs.Bool("pinned-first", ctx.config.PinnedFirst, "show pinned entries first")
-	if err := fs.Parse(args); err != nil {
-		return nil, fail(2, "%v", err)
+	if err := parseCommandFlags(fs, command, args); err != nil {
+		return nil, err
 	}
 	if len(fs.Args()) != 0 {
 		return nil, fail(2, "%s takes no positional arguments", command)
@@ -1161,8 +1247,7 @@ func writeConsoleLine(value string) {
 }
 
 func parseGet(args []string, cfg config.Config, g *globals) (operation.Selector, operation.Kind, bool, bool, bool, bool, error) {
-	fs := flag.NewFlagSet("get", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newFlagSet("get")
 	addOutputFlags(fs, g)
 	id := fs.String("id", "", "exact entry ID")
 	name := fs.String("name", "", "exact entry name")
@@ -1175,8 +1260,8 @@ func parseGet(args []string, cfg config.Config, g *globals) (operation.Selector,
 	newline := fs.Bool("newline", false, "ensure a final LF")
 	raw := fs.Bool("raw", false, "do not resolve template variables")
 	fs.BoolVar(newline, "n", false, "ensure a final LF")
-	if err := fs.Parse(args); err != nil {
-		return operation.Selector{}, operation.History, false, false, false, false, fail(2, "%v", err)
+	if err := parseCommandFlags(fs, "get", permuteArgs(fs, args)); err != nil {
+		return operation.Selector{}, operation.History, false, false, false, false, err
 	}
 	parsedKind, err := operation.ParseKind(*kind)
 	if err != nil {
@@ -1202,7 +1287,7 @@ func buildSelector(args []string, id, name, search string, first, caseSensitive 
 	}
 	if len(args) == 1 {
 		value, err := strconv.Atoi(args[0])
-		if err != nil {
+		if err != nil || value < 0 {
 			return operation.Selector{}, fail(2, "index must be a non-negative number")
 		}
 		index = &value
@@ -1221,6 +1306,11 @@ func readState(ctx *appContext) (syncengine.State, error) {
 		return state, mapRuntimeError("history could not be loaded", err)
 	}
 	merge.Normalize(&state.Database, time.Now().UnixMilli())
+	if state.Exists {
+		verbosef(ctx.globals, "downloaded revision %s, %d entries", state.Revision, len(state.Database.Entries))
+	} else {
+		verbosef(ctx.globals, "no database exists for this token and history password")
+	}
 	return state, nil
 }
 func selectionError(err error) error {
@@ -1366,7 +1456,7 @@ func escape(value string) string {
 	return replacer.Replace(value)
 }
 func printUsage(out io.Writer) {
-	fmt.Fprintln(out, "Clipman CLI - terminal access to Clipman text history\n\nUsage: clipman-cli [global options] <command> [options]\n\nCommands:\n  init     Configure a Clipman Server profile\n  status   Check server and history status\n  list     List text-history entries\n  get      Write one entry to standard output\n  put      Read UTF-8 text and add it to history\n  rm       Delete exactly one entry\n  pick     Select one entry and write it to standard output\n  menu     Open the accessible line-based history manager\n  sync     Download and validate current history\n\nGlobal options:\n  --config PATH     Select a configuration file\n  --server URL      Override the configured server\n  --password VALUE  Supply the history password\n  --ca-cert FILE    Trust an additional PEM CA/certificate for a self-signed server\n  --insecure        Disable TLS certificate verification (use only on a trusted network)\n  --json            Emit structured JSON where supported\n  --quiet, -q       Suppress nonessential messages\n  --version         Show version information")
+	fmt.Fprintln(out, "Clipman CLI - terminal access to Clipman text history\n\nUsage: clipman-cli [global options] <command> [options]\n\nCommands:\n  init     Configure a Clipman Server profile\n  status   Check server and history status\n  list     List text-history entries\n  get      Write one entry to standard output\n  put      Read UTF-8 text and add it to history\n  rm       Delete exactly one entry\n  pick     Select one entry and write it to standard output\n  menu     Open the accessible line-based history manager\n  sync     Download and validate current history\n\nGlobal options:\n  --config PATH     Select a configuration file\n  --server URL      Override the configured server\n  --password VALUE  Supply the history password\n  --ca-cert FILE    Trust an additional PEM CA/certificate for a self-signed server\n  --insecure        Disable TLS certificate verification (use only on a trusted network)\n  --json            Emit structured JSON where supported\n  --quiet, -q       Suppress nonessential messages\n  --verbose         Write diagnostic messages to standard error\n  --version         Show version information")
 }
 
 func printCommandUsage(out io.Writer, command string) bool {

--- a/ClipmanCli/cmd/clipman-cli/main_test.go
+++ b/ClipmanCli/cmd/clipman-cli/main_test.go
@@ -7,6 +7,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
+	"flag"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -18,6 +21,7 @@ import (
 	"time"
 
 	"github.com/OnjLouis/Clipman/ClipmanCli/internal/config"
+	"github.com/OnjLouis/Clipman/ClipmanCli/internal/operation"
 )
 
 func testServerWithCertificateChain(t *testing.T) (*httptest.Server, *x509.Certificate, *x509.Certificate) {
@@ -133,6 +137,190 @@ func TestResolvePasswordRequiresNonblankValue(t *testing.T) {
 	password, err := resolvePassword(globals{password: optionalString{set: true, value: "test-password"}}, config.Default(), false)
 	if err != nil || password != "test-password" {
 		t.Fatalf("nonblank history password = %q, %v", password, err)
+	}
+}
+
+// captureStdout runs body with standard output redirected and returns what it
+// wrote, so usage tests do not pollute the test log.
+func captureStdout(t *testing.T, body func()) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := os.Stdout
+	os.Stdout = write
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(read)
+		done <- string(data)
+	}()
+	body()
+	os.Stdout = saved
+	write.Close()
+	output := <-done
+	read.Close()
+	return output
+}
+
+// selectorFlags mirrors the option shapes that get and rm register: a mix of
+// options that take a value and options that do not.
+func selectorFlags() *flag.FlagSet {
+	fs := newFlagSet("get")
+	fs.String("id", "", "exact entry ID")
+	fs.String("kind", "history", "history, templates, or all")
+	fs.Bool("json", false, "write JSON output")
+	fs.Bool("touch", false, "mark the entry used")
+	return fs
+}
+
+func TestPermuteArgsAllowsOptionsAfterTheIndex(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"index then boolean option", []string{"0", "--json"}, []string{"--json", "--", "0"}},
+		{"index then option with a value", []string{"0", "--kind", "all"}, []string{"--kind", "all", "--", "0"}},
+		{"index between options", []string{"--touch", "3", "--json"}, []string{"--touch", "--json", "--", "3"}},
+		{"already in flag order", []string{"--json", "0"}, []string{"--json", "--", "0"}},
+		{"joined option value", []string{"0", "--kind=all"}, []string{"--kind=all", "--", "0"}},
+		{"no operands", []string{"--id", "abc", "--json"}, []string{"--id", "abc", "--json"}},
+		{"explicit separator is preserved", []string{"--json", "--", "0"}, []string{"--json", "--", "0"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := permuteArgs(selectorFlags(), testCase.args)
+			if strings.Join(got, " ") != strings.Join(testCase.want, " ") {
+				t.Fatalf("permuteArgs(%q) = %q, want %q", testCase.args, got, testCase.want)
+			}
+		})
+	}
+}
+
+// permuteArgs must not swallow the value of an option, which would turn
+// `--id 0` into a selector with an empty ID and a stray index.
+func TestPermuteArgsKeepsOptionValuesAttached(t *testing.T) {
+	got := permuteArgs(selectorFlags(), []string{"--id", "0"})
+	if strings.Join(got, " ") != "--id 0" {
+		t.Fatalf("permuteArgs = %q, want %q", got, "--id 0")
+	}
+}
+
+// An undefined option keeps reaching Parse so that it is still reported as a
+// usage error rather than silently treated as an index.
+func TestPermuteArgsLeavesUndefinedOptionsForParse(t *testing.T) {
+	got := permuteArgs(selectorFlags(), []string{"--nope"})
+	if strings.Join(got, " ") != "--nope" {
+		t.Fatalf("permuteArgs = %q, want %q", got, "--nope")
+	}
+}
+
+func TestParseGetAcceptsOptionsAfterTheIndex(t *testing.T) {
+	var g globals
+	selector, kind, _, touch, _, _, err := parseGet([]string{"0", "--json", "--touch", "--kind", "all"}, config.Default(), &g)
+	if err != nil {
+		t.Fatalf("parseGet returned %v", err)
+	}
+	if selector.Index == nil || *selector.Index != 0 {
+		t.Fatalf("selector index = %v, want 0", selector.Index)
+	}
+	if kind != operation.All {
+		t.Fatalf("kind = %q, want %q", kind, operation.All)
+	}
+	if !touch {
+		t.Fatal("--touch after the index was not applied")
+	}
+	if !g.json {
+		t.Fatal("--json after the index was not applied")
+	}
+}
+
+func TestBuildSelectorRejectsNegativeIndex(t *testing.T) {
+	_, err := buildSelector([]string{"-1"}, "", "", "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "non-negative") {
+		t.Fatalf("negative index error = %v", err)
+	}
+	var app appError
+	if !errors.As(err, &app) || app.code != 2 {
+		t.Fatalf("negative index exit code = %v, want 2", err)
+	}
+}
+
+func TestBuildSelectorRejectsCombinedSelectors(t *testing.T) {
+	if _, err := buildSelector([]string{"0"}, "some-id", "", "", false, false); err == nil {
+		t.Fatal("index combined with --id should fail")
+	}
+	if _, err := buildSelector([]string{"0", "1"}, "", "", "", false, false); err == nil {
+		t.Fatal("two indexes should fail")
+	}
+}
+
+func TestCommandHelpWorksAfterOtherOptions(t *testing.T) {
+	fs := selectorFlags()
+	var err error
+	output := captureStdout(t, func() {
+		err = parseCommandFlags(fs, "get", []string{"--json", "--help"})
+	})
+	if !errors.Is(err, errHelpRequested) {
+		t.Fatalf("parseCommandFlags returned %v, want errHelpRequested", err)
+	}
+	if !strings.Contains(output, "Usage: clipman-cli") {
+		t.Fatalf("help output = %q", output)
+	}
+	if printError(err) != 0 {
+		t.Fatal("requesting help must exit 0")
+	}
+}
+
+func TestEveryKnownCommandHasUsageText(t *testing.T) {
+	for _, command := range []string{"init", "status", "list", "get", "put", "rm", "sync", "pick", "menu", "help"} {
+		if !printCommandUsage(io.Discard, command) {
+			t.Fatalf("command %q has no usage text", command)
+		}
+	}
+	if printCommandUsage(io.Discard, "not-a-command") {
+		t.Fatal("unknown command reported usage text")
+	}
+}
+
+func captureStderr(t *testing.T, body func()) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := os.Stderr
+	os.Stderr = write
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(read)
+		done <- string(data)
+	}()
+	body()
+	os.Stderr = saved
+	write.Close()
+	output := <-done
+	read.Close()
+	return output
+}
+
+func TestVerboseDiagnosticsRequireTheOption(t *testing.T) {
+	quiet := captureStderr(t, func() { verbosef(globals{}, "server %s", "https://example.invalid") })
+	if quiet != "" {
+		t.Fatalf("diagnostics must stay off without --verbose, got %q", quiet)
+	}
+	suppressed := captureStderr(t, func() {
+		verbosef(globals{verbose: true, quiet: true}, "server %s", "https://example.invalid")
+	})
+	if suppressed != "" {
+		t.Fatalf("--quiet must win over --verbose, got %q", suppressed)
+	}
+	enabled := captureStderr(t, func() {
+		verbosef(globals{verbose: true}, "server %s", "https://example.invalid")
+	})
+	if !strings.Contains(enabled, "server https://example.invalid") {
+		t.Fatalf("verbose output = %q", enabled)
 	}
 }
 


### PR DESCRIPTION
## Summary

The release package put every binary in the root with the platform in the file name, so installing one meant renaming `clipman-cli-linux-arm64` to `clipman-cli`. Each platform now gets its own directory holding a program simply called `clipman-cli`, so installation is a move.

```
ClipmanCli-<version>/
├── windows-amd64/clipman-cli.exe
├── windows-arm64/clipman-cli.exe
├── macos-amd64/clipman-cli
├── macos-arm64/clipman-cli
├── linux-amd64/clipman-cli
├── linux-arm64/clipman-cli
├── linux-armv7/clipman-cli
├── manual/
│   ├── Manual.html
│   └── clipman-cli.1
├── LICENSE.txt
└── SHA256SUMS
```

**Windows ARM64 is a new target.** It was missing while macOS and Linux both shipped an arm64 build.

**`SHA256SUMS` stays at the package root** and now lists paths relative to it, so `sha256sum -c SHA256SUMS` verifies the entire package in one command from where it sits. `build.sh` normalizes the binary-mode `*` marker that some `sha256sum` builds emit (Git Bash on Windows, for one), so both build scripts write a byte-identical file.

## Verification

Ran `Build.ps1` and `build.sh` from clean and compared:

- Identical file trees.
- Byte-identical `SHA256SUMS` — the two scripts agree, and the builds are reproducible across them.
- All seven checksums verify with `sha256sum -c SHA256SUMS` from the package root.
- Windows binaries report PE machine types `0x8664` (amd64) and `0xaa64` (arm64), confirming the new target is genuinely ARM64 rather than a mislabeled x64 build.
- The packaged `windows-amd64` binary runs and reports its version.

Docs updated to match: the manual's Included Files section now lists the real paths and explains that installation is a move, and the man page's FILES section describes the directory layout and the verification command.

## Note

This is stacked on #57 — both changes touch `Manual.html` and `clipman-cli.1`, so branching from `main` would have produced a merge conflict. Merge #57 first and this diff becomes exactly the four files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
