### PR TITLE
Publish multi-arch (amd64 + arm64) clipman-server image

### DIFF
--- a/.github/workflows/clipman-server-container.yml
+++ b/.github/workflows/clipman-server-container.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -29,7 +35,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish image
+      - name: Resolve image tags
+        id: vars
         shell: bash
         run: |
           set -euo pipefail
@@ -44,12 +51,16 @@ jobs:
             echo "Invalid Clipman Server version: $version" >&2
             exit 1
           fi
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-          docker build \
-            -f ClipmanServerDocker/Dockerfile \
-            -t "${image}:latest" \
-            -t "${image}:${version}" \
-            .
-
-          docker push "${image}:latest"
-          docker push "${image}:${version}"
+      - name: Build and publish multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ClipmanServerDocker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.image }}:latest
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.version }}


### PR DESCRIPTION
## Problem

`ghcr.io/onjlouis/clipman-server` is currently only published for `linux/amd64`. Every tag I checked (2.5.0 through 2.6.4) has a single digest rather than a multi-platform manifest.

Running the published image on an ARM64 host (Raspberry Pi 4, 64-bit OS) fails immediately:

```
exec /usr/local/bin/clipman-server-entrypoint: exec format error
```

This is a straightforward architecture mismatch — the container keeps restarting because the kernel can't execute an amd64 binary on an aarch64 host.

## Root cause

`.github/workflows/clipman-server-container.yml` uses plain `docker build` / `docker push`, which only builds for the GitHub Actions runner's native architecture (amd64). There's no `buildx` or `--platform` flag, so no multi-arch manifest is ever produced.

## Fix

This PR switches the publish step to `docker/build-push-action` with QEMU + Buildx set up beforehand, building for both `linux/amd64` and `linux/arm64` under the same tags (`latest` and the resolved version). The version-resolution/validation logic is unchanged, just split into its own step so its outputs can feed the build-push action.

No changes were needed to the Dockerfile or entrypoint script — `clipman-server` is pure Python plus a POSIX shell entrypoint with no compiled or architecture-specific dependencies.

## Testing

**Reproduced the bug:** on a Raspberry Pi 4 (aarch64, 64-bit Raspberry Pi OS), pulling and running the published image with no platform override gives:

```
! clipman-server  The requested image's platform (linux/amd64) does not match
  the detected host platform (linux/arm64/v8) and no specific platform was requested
```

Docker attempts to run it anyway, and the container crash-loops with `exec /usr/local/bin/clipman-server-entrypoint: exec format error` on every restart, matching the original bug report exactly.

**Confirmed the fix works:** built this Dockerfile natively on the same Pi with a plain `docker build -f ClipmanServerDocker/Dockerfile .` (no QEMU or platform flags needed, since it's a native arm64 build) and ran it via Compose. The server started cleanly with no crash loop, and `/api/v1/health` responded successfully both locally and over the network.

Together these confirm the failure is specific to the missing arm64 manifest, not the application code, config, or Compose setup — and that the app builds and runs correctly on arm64 once it's actually built for that platform.

I wasn't able to test the actual `ghcr.io` publish step end-to-end, since Actions on my fork don't have push access to the upstream `ghcr.io/onjlouis/*` package.

## Notes for review

- The arm64 leg builds under QEMU emulation on the amd64 GitHub runner, so this will make the publish workflow noticeably slower than before. Happy to look at a native arm64 runner instead if preferred, but this seemed like the simpler starting point.
- Tags and versioning behavior are unchanged — this only affects which platforms get built into each tag.

Opened this after running into the issue myself while self-hosting on a Pi; happy to adjust the approach if you'd prefer a different structure.